### PR TITLE
Introduce clipboard backend abstraction

### DIFF
--- a/bounceboard/clipboard/__init__.py
+++ b/bounceboard/clipboard/__init__.py
@@ -1,67 +1,28 @@
-import platform
 import logging
-import pyperclip
+import platform
 
-from .common import calculate_hash
-from .linux import get_content as _linux_get, set_content as _linux_set
-from .macos import get_content as _macos_get, set_content as _macos_set
-from .win import get_content as _win_get, set_content as _win_set
+from .backends import get_backend, PyperclipBackend
 
-def _pyperclip_get():
-    try:
-        text = pyperclip.paste()
-        if not text:
-            return None
-        data = text.encode('utf-8')
-        return ({
-            'type': 'text/plain', 
-            'size': len(data),
-            'hash': calculate_hash(data)
-        }, data)
-    except:
-        return None
-
-def _pyperclip_set(clipboard, temp_dir=None):
-    try:
-        header, data = clipboard
-        if header['type'] != 'text/plain':
-            logging.warning(f"Falling back to text/plain for {header['type']}")
-        pyperclip.copy(data.decode('utf-8'))
-        return True
-    except:
-        return False
+_backend = get_backend(platform.system())
+_fallback = PyperclipBackend()
 
 def get_content():
-    system = platform.system()
     try:
-        if system == "Linux":
-            result = _linux_get()
-        elif system == "Darwin":
-            result = _macos_get()
-        elif system == "Windows":
-            result = _win_get()
-            
+        result = _backend.get_content()
         if result is not None:
             return result
-            
     except Exception:
-        logging.exception(f"Native clipboard access failed for {system}, defaulting to text-only")
-    
-    return _pyperclip_get()
+        logging.exception(
+            f"Native clipboard access failed for {platform.system()}, defaulting to text-only"
+        )
+    return _fallback.get_content()
 
 def set_content(clipboard, temp_dir=None):
-    system = platform.system()
     try:
-        if system == "Linux":
-            if _linux_set(clipboard, temp_dir):
-                return True
-        elif system == "Darwin":
-            if _macos_set(clipboard, temp_dir):
-                return True
-        elif system == "Windows":
-            if _win_set(clipboard, temp_dir):
-                return True
+        if _backend.set_content(clipboard, temp_dir):
+            return True
     except Exception:
-        logging.exception(f"Native clipboard access failed for {system}, defaulting to text-only")
-    
-    return _pyperclip_set(clipboard, temp_dir)
+        logging.exception(
+            f"Native clipboard access failed for {platform.system()}, defaulting to text-only"
+        )
+    return _fallback.set_content(clipboard, temp_dir)

--- a/bounceboard/clipboard/backends.py
+++ b/bounceboard/clipboard/backends.py
@@ -1,0 +1,79 @@
+class ClipboardBackend:
+    """Abstract clipboard backend."""
+
+    def get_content(self):
+        raise NotImplementedError
+
+    def set_content(self, clipboard, temp_dir=None):
+        raise NotImplementedError
+
+
+class LinuxBackend(ClipboardBackend):
+    def get_content(self):
+        from .linux import get_content as _get
+        return _get()
+
+    def set_content(self, clipboard, temp_dir=None):
+        from .linux import set_content as _set
+        return _set(clipboard, temp_dir)
+
+
+class MacOSBackend(ClipboardBackend):
+    def get_content(self):
+        from .macos import get_content as _get
+        return _get()
+
+    def set_content(self, clipboard, temp_dir=None):
+        from .macos import set_content as _set
+        return _set(clipboard, temp_dir)
+
+
+class WindowsBackend(ClipboardBackend):
+    def get_content(self):
+        from .win import get_content as _get
+        return _get()
+
+    def set_content(self, clipboard, temp_dir=None):
+        from .win import set_content as _set
+        return _set(clipboard, temp_dir)
+
+
+class PyperclipBackend(ClipboardBackend):
+    def get_content(self):
+        import pyperclip
+        from .common import calculate_hash
+        try:
+            text = pyperclip.paste()
+            if not text:
+                return None
+            data = text.encode("utf-8")
+            return ({
+                "type": "text/plain",
+                "size": len(data),
+                "hash": calculate_hash(data),
+            }, data)
+        except Exception:
+            return None
+
+    def set_content(self, clipboard, temp_dir=None):
+        import pyperclip
+        try:
+            header, data = clipboard
+            if header["type"] != "text/plain":
+                import logging
+                logging.warning(f"Falling back to text/plain for {header['type']}")
+            pyperclip.copy(data.decode("utf-8"))
+            return True
+        except Exception:
+            return False
+
+
+BACKENDS = {
+    "Linux": LinuxBackend,
+    "Darwin": MacOSBackend,
+    "Windows": WindowsBackend,
+}
+
+
+def get_backend(system):
+    return BACKENDS.get(system, PyperclipBackend)()

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -1,0 +1,40 @@
+import unittest
+from unittest import mock
+
+from bounceboard.clipboard import backends as cb_backends
+import bounceboard.clipboard as clipboard
+
+
+class DummyBackend(cb_backends.ClipboardBackend):
+    def __init__(self):
+        self.get_called = False
+        self.set_called = False
+
+    def get_content(self):
+        self.get_called = True
+        return ({'type': 'text/plain', 'size': 0, 'hash': '0'}, b'')
+
+    def set_content(self, clipboard_item, temp_dir=None):
+        self.set_called = True
+        return True
+
+
+class BackendTests(unittest.TestCase):
+    def test_backend_selection(self):
+        self.assertIsInstance(cb_backends.get_backend('Linux'), cb_backends.LinuxBackend)
+        self.assertIsInstance(cb_backends.get_backend('Darwin'), cb_backends.MacOSBackend)
+        self.assertIsInstance(cb_backends.get_backend('Windows'), cb_backends.WindowsBackend)
+        self.assertIsInstance(cb_backends.get_backend('Other'), cb_backends.PyperclipBackend)
+
+    def test_delegation(self):
+        dummy = DummyBackend()
+        with mock.patch.object(clipboard, '_backend', dummy), \
+             mock.patch.object(clipboard, '_fallback', dummy):
+            clipboard.get_content()
+            clipboard.set_content(({'type': 'text/plain'}, b''))
+        self.assertTrue(dummy.get_called)
+        self.assertTrue(dummy.set_called)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- refactor clipboard access behind backend classes
- support Linux, macOS, Windows and a Pyperclip fallback
- update clipboard module to delegate to the selected backend
- add basic unit tests for backend selection and delegation

## Testing
- `python -m unittest discover -v tests`